### PR TITLE
Amended process for removing erroneous images

### DIFF
--- a/Image Set Download.ipynb
+++ b/Image Set Download.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -86,7 +86,7 @@
        " '/static/images/poweredby_mediawiki_88x31.png']"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -109,8 +109,12 @@
     }
    ],
    "source": [
-    "#remove thumbnails identified in initial list\n",
-    "tags = tags[0:-3]\n",
+    "#remove thumbnails identified in initial list, ensuring only images are from 'upload.wikimedia' pages\n",
+    "\n",
+    "for link in tags:\n",
+    "    if 'upload.wikimedia' not in link:\n",
+    "        tags.remove(link)\n",
+    "        \n",
     "print(len(tags))"
    ]
   },


### PR DESCRIPTION
Used list comprehension rather than index based removal to get rid of erroneous images (i.e. web page thumbnails) from desired set.